### PR TITLE
Add additional SELinux rules for MTK devices

### DIFF
--- a/magiskmodule/sepolicy.rule
+++ b/magiskmodule/sepolicy.rule
@@ -8,3 +8,7 @@ allow hal_audio_default hal_audio_default_tmpfs file { execute }
 allow hal_audio_default audio_data_file dir { search }
 allow app app_data_file file { execute_no_trans }
 allow mtk_hal_audio mtk_hal_audio_tmpfs file { execute }
+allow mtk_hal_audio sysfs_dt_firmware_android file { read }
+allow mtk_hal_audio mtk_hal_audio process { execmem }
+allow mtk_hal_audio metadata_file dir { search }
+allow mtk_hal_audio debugfs_ion dir { search }


### PR DESCRIPTION
This adds more SELinux rules for MTK devices, as documented [here](https://forum.xda-developers.com/t/mod-viper4android-miui-12-magisk-21-1.4203489/).

I would like several people to confirm that this is actually necessary, 
by installing the normal version and confirming it's not working
and then installing a version with the changes of this PR and confirming it then works.
