### PR TITLE
Add OneUI 5 to tested ROMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ It has been tested to work on:
 * `LineageOS 18.1`
 * `LineageOS 19.1`
 * `LineageOS 20.0`
+* `OneUI 5.0`
 
 ## Bugs and support
 


### PR DESCRIPTION
Hi there! I am currently running your Magisk Module on OneUI 5 and I was thinking into adding that to the Tested ROMs sections.

![Screenshot_20230205_221022](https://user-images.githubusercontent.com/32200281/216846058-4eff3a35-932d-4544-82d0-c072ab75c950.jpg)

![Screenshot_20230205_221155_ViPER4Android FX](https://user-images.githubusercontent.com/32200281/216846078-5f641584-79b9-46d6-8b89-2a84aa2683a2.jpg)
